### PR TITLE
- [+] add read from url support, close #34

### DIFF
--- a/ext/decoders.go
+++ b/ext/decoders.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -153,6 +155,12 @@ func (r *Reader) Decode(s string) error {
 	if s == "" {
 		r.reader = os.Stdin
 		r.filename = os.Stdin.Name()
+	} else if regexp.MustCompile(`(?i)^http`).MatchString(s) {
+		response, err := http.Get(s)
+		if err != nil {
+			return err
+		}
+		r.reader = response.Body
 	} else {
 		r.filename = s
 		file, err := os.Open(s)


### PR DESCRIPTION

```
$ go run 028-reader-Net.go -r https://gist.githubusercontent.com/suntong/5a306a6cddf501042df88624caff3b48/raw/4c8aa065ba06d669b6a985e61ca1d0b280c39724/test.txt
reade from reader: 'This is a simple test in text. '
```

and [028-reader-Net.go is available here](https://github.com/suntong/lang/blob/master/lang/Go/src/sys/CLI/028-reader-Net.go). 
