### PR TITLE
Fix issue #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Examples
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -73,11 +75,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("Hello, %s!\n", argv.Name)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -98,6 +100,8 @@ Hello, Clipher!
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -109,11 +113,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("port=%d, x=%v, y=%v\n", argv.Port, argv.X, argv.Y)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -149,6 +153,8 @@ port=8080, x=true, y=true
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -158,11 +164,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%d\n", argv.Id)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -185,6 +191,8 @@ $ ./app --id=2
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -197,11 +205,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%d, %s, %d, %s\n", argv.Basic, argv.Env, argv.Expr, argv.DevDir)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -232,6 +240,8 @@ $ BASE_PORT=8000 ./app --basic=3
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -241,10 +251,10 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }
 ```
 
@@ -267,6 +277,8 @@ $ ./app -FAlice -FBob -F Charlie
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -275,10 +287,10 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }
 ```
 
@@ -305,6 +317,8 @@ $ ./app -Dx=1 -D y=2
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -314,13 +328,13 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		if argv.Version {
 			ctx.String("v0.0.1\n")
 		}
 		return nil
-	})
+	}))
 }
 ```
 
@@ -451,6 +465,8 @@ Did you mean child?
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -465,9 +481,9 @@ func (argv *argT) AutoHelp() bool {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		return nil
-	})
+	}))
 }
 ```
 
@@ -493,6 +509,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mkideal/cli"
 )
@@ -515,10 +532,10 @@ func (argv *argT) Validate(ctx *cli.Context) error {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }
 ```
 
@@ -545,6 +562,8 @@ $ ./app --age 88 --gender female
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -555,11 +574,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("username=%s, password=%s\n", argv.Username, argv.Password)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -582,6 +601,7 @@ username=hahaha, password=123456
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/mkideal/cli"
@@ -602,11 +622,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONln(argv.Example.list)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -627,6 +647,8 @@ $ ./app -d a,b,c
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -637,7 +659,7 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 
 		if err := argv.PidFile.New(); err != nil {
@@ -646,7 +668,7 @@ func main() {
 		defer argv.PidFile.Remove()
 
 		return nil
-	})
+	}))
 }
 ```
 
@@ -661,6 +683,8 @@ func main() {
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -671,11 +695,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("time=%v, duration=%v\n", argv.Time, argv.Duration)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -696,6 +720,8 @@ time=2016-01-02 03:05:00 +0800 CST, duration=10ms
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -705,11 +731,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String(argv.Content.String())
 		return nil
-	})
+	}))
 }
 ```
 
@@ -742,6 +768,8 @@ $ rm test.txt
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -756,11 +784,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONIndentln(argv.JSON, "", "    ")
 		return nil
-	})
+	}))
 }
 ```
 
@@ -792,6 +820,8 @@ $ ./app -c '{"A": "hello", "b": 22, "C": true}'
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -806,11 +836,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONIndentln(argv.JSON, "", "    ")
 		return nil
-	})
+	}))
 }
 ```
 
@@ -837,6 +867,7 @@ $ rm test.json
 package main
 
 import (
+	"os"
 	"reflect"
 
 	"github.com/mkideal/cli"
@@ -888,11 +919,11 @@ func main() {
 	// register parser factory function
 	cli.RegisterFlagParser("myparser", newMyParser)
 
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%v\n", argv.Cfg)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -1048,6 +1079,7 @@ func main() {
 		cli.Tree(daemon),
 	).Run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 
@@ -1104,6 +1136,8 @@ $ ps | grep daemon-app
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -1113,11 +1147,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("msg: %s", argv.Msg)
 		return nil
-	})
+	}))
 }
 ```
 
@@ -1157,11 +1191,11 @@ func main() {
 		}
 		return cli.DefaultEditor, nil
 	}
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("msg: %s", argv.Msg)
 		return nil
-	})
+	}))
 }
 ```
 

--- a/_examples/001-hello/main.go
+++ b/_examples/001-hello/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/mkideal/cli"
+	"os"
 )
 
 type helloT struct {
@@ -11,9 +12,9 @@ type helloT struct {
 }
 
 func main() {
-	cli.Run(new(helloT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(helloT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*helloT)
 		ctx.String("Hello, %s! Your age is %d?\n", argv.Name, argv.Age)
 		return nil
-	})
+	}))
 }

--- a/_examples/002-flag/main.go
+++ b/_examples/002-flag/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -12,9 +14,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("port=%d, x=%v, y=%v\n", argv.Port, argv.X, argv.Y)
 		return nil
-	})
+	}))
 }

--- a/_examples/003-required-flag/main.go
+++ b/_examples/003-required-flag/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,9 +12,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%d\n", argv.Id)
 		return nil
-	})
+	}))
 }

--- a/_examples/004-default-flag/main.go
+++ b/_examples/004-default-flag/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -13,9 +15,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%d, %s, %d, %s\n", argv.Basic, argv.Env, argv.Expr, argv.DevDir)
 		return nil
-	})
+	}))
 }

--- a/_examples/005-slice/main.go
+++ b/_examples/005-slice/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,8 +12,8 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }

--- a/_examples/006-map/main.go
+++ b/_examples/006-map/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -9,8 +11,8 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }

--- a/_examples/007-force-flag/main.go
+++ b/_examples/007-force-flag/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,11 +12,11 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		if argv.Version {
 			ctx.String("v0.0.1\n")
 		}
 		return nil
-	})
+	}))
 }

--- a/_examples/009-auto-helper/main.go
+++ b/_examples/009-auto-helper/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -15,7 +17,7 @@ func (argv *argT) AutoHelp() bool {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		return nil
-	})
+	}))
 }

--- a/_examples/010-validator/main.go
+++ b/_examples/010-validator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mkideal/cli"
 )
@@ -24,8 +25,8 @@ func (argv *argT) Validate(ctx *cli.Context) error {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		ctx.JSONln(ctx.Argv())
 		return nil
-	})
+	}))
 }

--- a/_examples/011-prompt-and-password/main.go
+++ b/_examples/011-prompt-and-password/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -11,9 +13,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("username=%s, password=%s\n", argv.Username, argv.Password)
 		return nil
-	})
+	}))
 }

--- a/_examples/012-decoder/main.go
+++ b/_examples/012-decoder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/mkideal/cli"
@@ -21,9 +22,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONln(argv.Example.list)
 		return nil
-	})
+	}))
 }

--- a/_examples/013-pidfile/main.go
+++ b/_examples/013-pidfile/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -11,7 +13,7 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 
 		if err := argv.PidFile.New(); err != nil {
@@ -20,5 +22,5 @@ func main() {
 		defer argv.PidFile.Remove()
 
 		return nil
-	})
+	}))
 }

--- a/_examples/014-time-and-duration/main.go
+++ b/_examples/014-time-and-duration/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -11,9 +13,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("time=%v, duration=%v\n", argv.Time, argv.Duration)
 		return nil
-	})
+	}))
 }

--- a/_examples/015-file/main.go
+++ b/_examples/015-file/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
 )
@@ -10,9 +12,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String(argv.Content.String())
 		return nil
-	})
+	}))
 }

--- a/_examples/016-parser/main.go
+++ b/_examples/016-parser/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -15,9 +17,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONIndentln(argv.JSON, "", "    ")
 		return nil
-	})
+	}))
 }

--- a/_examples/017-jsonfile/main.go
+++ b/_examples/017-jsonfile/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -15,9 +17,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.JSONIndentln(argv.JSON, "", "    ")
 		return nil
-	})
+	}))
 }

--- a/_examples/018-custom-parser/main.go
+++ b/_examples/018-custom-parser/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"reflect"
 
 	"github.com/mkideal/cli"
@@ -52,9 +53,9 @@ func main() {
 	// register parser factory function
 	cli.RegisterFlagParser("myparser", newMyParser)
 
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("%v\n", argv.Cfg)
 		return nil
-	})
+	}))
 }

--- a/_examples/020-daemon/main.go
+++ b/_examples/020-daemon/main.go
@@ -21,6 +21,7 @@ func main() {
 		cli.Tree(daemon),
 	).Run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 

--- a/_examples/021-editor/main.go
+++ b/_examples/021-editor/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,9 +12,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("msg: %s", argv.Msg)
 		return nil
-	})
+	}))
 }

--- a/_examples/022-custom-editor/main.go
+++ b/_examples/022-custom-editor/main.go
@@ -18,9 +18,9 @@ func main() {
 		}
 		return cli.DefaultEditor, nil
 	}
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("msg: %s", argv.Msg)
 		return nil
-	})
+	}))
 }

--- a/_examples/023-tree/main.go
+++ b/_examples/023-tree/main.go
@@ -25,6 +25,7 @@ func main() {
 
 	if err := root.Run(os.Args[1:]); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 

--- a/_examples/025-rpc/main.go
+++ b/_examples/025-rpc/main.go
@@ -22,6 +22,7 @@ func main() {
 		),
 	).Run(os.Args[1:]); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 

--- a/_examples/026-http/main.go
+++ b/_examples/026-http/main.go
@@ -18,6 +18,7 @@ func main() {
 		),
 	).Run(os.Args[1:]); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 

--- a/_examples/027-global-option/main.go
+++ b/_examples/027-global-option/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	if err := cli.Root(root, cli.Tree(sub)).Run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 

--- a/_examples/028-reader/main.go
+++ b/_examples/028-reader/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/mkideal/cli"
@@ -13,7 +14,7 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		data, err := ioutil.ReadAll(argv.Reader)
 		argv.Reader.Close()
@@ -32,5 +33,5 @@ func main() {
 		ctx.String("reade from reader: %s\n", string(data))
 		ctx.String("filename: %s, isStdin=%v\n", argv.Reader.Name(), argv.Reader.IsStdin())
 		return nil
-	})
+	}))
 }

--- a/_examples/029-writer/main.go
+++ b/_examples/029-writer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 
 	"github.com/mkideal/cli"
 	clix "github.com/mkideal/cli/ext"
@@ -12,7 +13,7 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		argv.Writer.Close()
 		n, err := argv.Writer.Write([]byte("hello,writer\n"))
@@ -33,5 +34,5 @@ func main() {
 		ctx.String("writes %d bytes to bytes.Writer: %s\n", n, w.String())
 		ctx.String("filename: %s, isStdout: %v\n", argv.Writer.Name(), argv.Writer.IsStdout())
 		return nil
-	})
+	}))
 }

--- a/_examples/030-counter/main.go
+++ b/_examples/030-counter/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,9 +12,9 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		ctx.String("v=%d\n", argv.V.Value())
 		return nil
-	})
+	}))
 }

--- a/cli.go
+++ b/cli.go
@@ -11,12 +11,12 @@ import (
 )
 
 // Run runs a single command app
-func Run(argv interface{}, fn CommandFunc, descs ...string) {
-	RunWithArgs(argv, os.Args, fn, descs...)
+func Run(argv interface{}, fn CommandFunc, descs ...string) int {
+	return RunWithArgs(argv, os.Args, fn, descs...)
 }
 
 // RunWithArgs is similar to Run, but with args instead of os.Args
-func RunWithArgs(argv interface{}, args []string, fn CommandFunc, descs ...string) {
+func RunWithArgs(argv interface{}, args []string, fn CommandFunc, descs ...string) int {
 	desc := ""
 	if len(descs) > 0 {
 		desc = strings.Join(descs, "\n")
@@ -30,7 +30,9 @@ func RunWithArgs(argv interface{}, args []string, fn CommandFunc, descs ...strin
 	}).Run(args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		return 1
 	}
+	return 0
 }
 
 // Root registers forest for root and returns root

--- a/cmd/clint/main.go
+++ b/cmd/clint/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mkideal/cli"
 )
 
@@ -10,12 +12,12 @@ type argT struct {
 }
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)
 		if argv.Version {
 			ctx.String("%v\n", appVersion)
 			return nil
 		}
 		return nil
-	})
+	}))
 }

--- a/cmd/yocli/main.go
+++ b/cmd/yocli/main.go
@@ -118,7 +118,7 @@ var {{.Name}} = &cli.Command{
 `
 
 func main() {
-	cli.Run(new(argT), func(ctx *cli.Context) error {
+	os.Exit(cli.Run(new(argT), func(ctx *cli.Context) error {
 		cli.SetUsageStyle(cli.ManualStyle)
 		argv := ctx.Argv().(*argT)
 		if argv.Help {
@@ -133,5 +133,5 @@ func main() {
 %s:
 	clier hello
 	clier -f -s "balabalabala" hello
-	clier -p balabala hello`, color.Bold("clier"), color.Bold("Usage"), color.Bold("Examples")))
+	clier -p balabala hello`, color.Bold("clier"), color.Bold("Usage"), color.Bold("Examples"))))
 }

--- a/run-examples.sh
+++ b/run-examples.sh
@@ -11,7 +11,7 @@ do
 	cd $EXAMPLE_DIR/$APP
 	SCRIPT="./run.sh"
 	if [ -f "$SCRIPT" ]; then
-		echo ">>>> exmaple: $APP"
+		echo ">>>> example: $APP"
 		chmod +x $SCRIPT
 		$SCRIPT
 	fi


### PR DESCRIPTION
A failing CLI execution [must return a non-zero exitcode](https://en.wikipedia.org/wiki/Exit_status).

It would be nice to call `os.Exit` automatically with proper exit codes, when execution fails. Features such as "different exitcode for errors 'value for given parameter invalid' and 'parameter missing'" would be nice. However, we can also keep it simple and just return 0 (success) and 1 (any error). If so, we don't call `os.Exit` automatically, keep testing simpler and do not break backwards compatibility.

This fix keeps its it very simple with minimal code change:
Introduce an integer return value for `func Run(...)` in cli.go.
This integer can be passed to `os.Exit` as recommended by all examples.

```
  % git diff -u cli.go
  diff --git a/cli.go b/cli.go
  index 41ce39e..64fb55c 100644
  --- a/cli.go
  +++ b/cli.go
  @@ -11,12 +11,12 @@ import (
   )

   // Run runs a single command app
  -func Run(argv interface{}, fn CommandFunc, descs ...string) {
  -       RunWithArgs(argv, os.Args, fn, descs...)
  +func Run(argv interface{}, fn CommandFunc, descs ...string) int {
  +       return RunWithArgs(argv, os.Args, fn, descs...)
   }

   // RunWithArgs is similar to Run, but with args instead of os.Args
  -func RunWithArgs(argv interface{}, args []string, fn CommandFunc, descs
  ...string) {
  +func RunWithArgs(argv interface{}, args []string, fn CommandFunc, descs
  ...string) int {
          desc := ""
          if len(descs) > 0 {
                  desc = strings.Join(descs, "\n")
  @@ -30,7 +30,9 @@ func RunWithArgs(argv interface{}, args []string, fn
  CommandFunc, descs ...strin
          }).Run(args[1:])
          if err != nil {
                  fmt.Fprintln(os.Stderr, err)
  +               return 1
          }
  +       return 0
   }
```

(Also fixes one typo in "run-examples.sh")